### PR TITLE
Handle roman numerals in TagRx

### DIFF
--- a/organize-multidisk.ps1
+++ b/organize-multidisk.ps1
@@ -17,7 +17,7 @@ param(
 
 # 1 ─ settings ─────────────────────────────────────────────
 $ExtAll   = ".cue", ".iso", ".img", ".chd", ".bin", ".wav", ".pbp"
-$TagRx    = '(?i)[\s\-_]*(?:[\(\[\{]?)(?:disc|disk|cd|d|part|p|track)[\s\-_]*([0-9]{1,2})(?:[\)\]\}]?)'
+$TagRx    = '(?i)[\s\-_]*(?:[\(\[\{]?)(?:disc|disk|cd|d|part|p|track)[\s\-_]*(?:([0-9]{1,2}|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve))(?:[\)\]\}]?)'
 # ─────────────────────────────────────────────────────────
 
 if (-not (Test-Path $Path)) { throw "Path '$Path' does not exist." }


### PR DESCRIPTION
## Summary
- extend `$TagRx` so `Disc I/II/III` and words like `Disc One` are recognized

## Testing
- `perl -e` regex test to verify removal of Roman numerals and spelled numbers

------
https://chatgpt.com/codex/tasks/task_b_685952311a3c832690161cb1604ff407