### PR TITLE
Fix directory creation on older PowerShell

### DIFF
--- a/organize-multidisk.ps1
+++ b/organize-multidisk.ps1
@@ -65,7 +65,7 @@ function Move-File($src, $dstDir) {
     if (-not (Test-Path -LiteralPath $src)) { return $null }        # already moved
     if (-not (Test-Path -LiteralPath $dstDir)) {
         if ($DryRun) { Write-Host "[DRYRUN] mkdir $dstDir" }
-        else { New-Item -ItemType Directory -LiteralPath $dstDir -Force | Out-Null }
+        else { New-Item -ItemType Directory -Path $dstDir -Force | Out-Null }
     }
     $dst = Join-Path $dstDir ([IO.Path]::GetFileName($src))
     if ($src -ne $dst) {


### PR DESCRIPTION
## Summary
- ensure compatibility with Windows PowerShell
- create folders using `-Path` since `-LiteralPath` isn't available for `New-Item`

## Testing
- `apt-get update`
- `apt-get install -y powershell` *(fails: `Unable to locate package powershell`)*

------
https://chatgpt.com/codex/tasks/task_b_6859f8359dd883269d2e1065751d0ffc