### PR TITLE
Fix disc tag regex to stop corrupting titles

### DIFF
--- a/organize-multidisk.ps1
+++ b/organize-multidisk.ps1
@@ -42,7 +42,7 @@ param(
 
 # 1 ─ settings ─────────────────────────────────────────────
 $ExtAll   = ".cue", ".iso", ".img", ".chd", ".bin", ".wav", ".pbp"
-$TagRx    = '(?i)[\s\-_]*(?:[\(\[\{]?)(?:disc|disk|cd|d|part|p|track)[\s\-_]*(?:([0-9]{1,2}|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve))(?:[\)\]\}]?)'
+$TagRx    = '(?i)(?:^|[\s\-_\(\[\{])(disc|disk|cd|d|part|p|track)[\s\-_]*(?:([0-9]{1,2}|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve))(?:[\)\]\}]?)'
 # ─────────────────────────────────────────────────────────
 
 if (-not (Test-Path -LiteralPath $Path)) { throw "Path '$Path' does not exist." }


### PR DESCRIPTION
## Summary
- refine the regex that strips disc tags

## Testing
- `apt-get install -y powershell` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859ffb5beac8326b11e2b0abab97012