### PR TITLE
Fix regex to avoid truncating game titles

### DIFF
--- a/organize-multidisk.ps1
+++ b/organize-multidisk.ps1
@@ -42,7 +42,7 @@ param(
 
 # 1 ─ settings ─────────────────────────────────────────────
 $ExtAll   = ".cue", ".iso", ".img", ".chd", ".bin", ".wav", ".pbp"
-$TagRx    = '(?i)(?:^|[\s\-_\(\[\{])(disc|disk|cd|d|part|p|track)[\s\-_]*(?:([0-9]{1,2}|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve))(?:[\)\]\}]?)'
+$TagRx    = '(?i)(?:^|[\s\-_\(\[\{])(disc|disk|cd|d|part|p|track)[\s\-_]*([0-9]{1,2}|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)(?:[\)\]\}]|\b)'
 # ─────────────────────────────────────────────────────────
 
 if (-not (Test-Path -LiteralPath $Path)) { throw "Path '$Path' does not exist." }


### PR DESCRIPTION
## Summary
- prevent disc tag regex from matching partial words

## Testing
- `python3 - <<'PY'
import re
pattern = r"(?i)(?:^|[\s\-_\(\[\{])(disc|disk|cd|d|part|p|track)[\s\-_]*([0-9]{1,2}|[ivxlcdm]+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)(?:[\)\]\}]|\b)"
regex = re.compile(pattern)
print(regex.sub('', 'Street Fighter EX Plus Alpha (USA) (Disc 1)').strip(' .-_'))
PY

------
https://chatgpt.com/codex/tasks/task_b_685a8829aa24832688b285cfbdb76aea